### PR TITLE
testfile for sbi_probe_extension

### DIFF
--- a/code/src/test_srcs/test__sbi_probe_extension/test__sbi_probe_extension.c
+++ b/code/src/test_srcs/test__sbi_probe_extension/test__sbi_probe_extension.c
@@ -1,0 +1,44 @@
+#include "test_macros.h"
+
+int test_case(void);
+
+/**
+ * @brief interrupt handler function that runs in S-mode. Not used in this test
+ * 
+ */
+__attribute__((interrupt("supervisor")))
+void s_mode_trap(void) {
+  uint64_t cause = read_csr(scause);
+
+  switch (cause) {
+    default:
+      break;
+  }
+}
+
+/**
+ * @brief Test case example checks for illegal instruction exception
+ * 
+ * @return int 
+ */
+int test_case(void) {
+  struct sbiret get_spec = sbi_probe_extension(EID_10);
+
+  if(get_spec.value == 1)
+    {
+        exit_test(6);
+        if(get_spec.error == SBI_SUCCESS)
+        {
+            exit_test(TEST_PASS);
+        }
+     }
+
+  /*sbi_spec_version val;
+  val.full_ver = get_spec.value;
+  if (val.major_ver != 0)
+    exit_test(TEST_FAIL);
+  if (val.minor_ver != 2)
+    exit_test(TEST_FAIL);*/
+else
+  {exit_test(10);}
+}

--- a/testlists/test__sbi_get_spec_version.sh
+++ b/testlists/test__sbi_get_spec_version.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
 
 source export.sh
-make TEST_DIR="code/src/test_srcs/test__sbi_get_spec_version" CFLAGS="-DDEBUG"
+make TEST_DIR="code/src/test_srcs/test__sbi_probe_extension" CFLAGS="-DDEBUG"
 make spike


### PR DESCRIPTION
# Pull Request Template

## Prequisites

- [ ] Did you run lint -cf `filename` on your changes, if you are commiting a .c file?
- [ ] Did you run lint -sf `filename` on your changes, if you are commiting a .sh file?
- [ ] Does your code compile properly using `make`?
- [ ] Did you related issue number in the description?

## Description
#25 
Function sbi_probe_extension:
for EID -> 0x10
value is (0xffffffff) instead of required value (1)
error is (0xffffffffffffffff) instead of required error value (0)

## Technical Debt

<Write about any missing things that you are going to do in the future related to this PR>
